### PR TITLE
Add minimum refuel amount value in crosschain quote response from socket

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.15",
+  "version": "0.1.16",
   "name": "@rainbow-me/swaps",
   "license": "GPL-3.0",
   "main": "dist/index.js",

--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -1,4 +1,4 @@
-import { BigNumberish } from '@ethersproject/bignumber';
+import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Transaction } from '@ethersproject/transactions';
@@ -140,7 +140,7 @@ const buildRainbowCrosschainQuoteUrl = ({
  * @param {ChainId} params.toChainId
  * @returns {string}
  */
-const getMinRefuelAmount = async (params: {
+export const getMinRefuelAmount = async (params: {
   chainId: ChainId;
   toChainId: ChainId;
 }): Promise<BigNumberish | null> => {
@@ -278,8 +278,6 @@ export const getCrosschainQuote = async (
     return null;
   }
 
-  const minRefuelAmount = await getMinRefuelAmount({ chainId, toChainId });
-
   const url = buildRainbowCrosschainQuoteUrl({
     buyTokenAddress,
     chainId,
@@ -296,7 +294,7 @@ export const getCrosschainQuote = async (
   if (quote.error) {
     return quote as QuoteError;
   }
-  return { ...quote, minRefuelAmount } as CrosschainQuote;
+  return quote as CrosschainQuote;
 };
 
 const calculateDeadline = async (wallet: Wallet) => {

--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -24,7 +24,6 @@ import {
   MAX_INT,
   PERMIT_EXPIRATION_TS,
   RAINBOW_ROUTER_CONTRACT_ADDRESS,
-  SOCKET_BASE_URL,
   WRAPPED_ASSET,
 } from './utils/constants';
 import { signPermit } from '.';
@@ -146,7 +145,7 @@ const getMinRefuelAmount = async (params: {
   toChainId: ChainId;
 }): Promise<BigNumberish | null> => {
   const { chainId, toChainId } = params;
-  const url = `${SOCKET_BASE_URL}/chains`;
+  const url = `${API_BASE_URL}/chains`;
   const response = await fetch(url);
   const chainsData = (await response.json()) as SocketChainsData;
 

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -205,7 +205,6 @@ export interface CrosschainQuote extends Quote {
   allowanceTarget?: string;
   routes: SocketRoute[];
   refuel: SocketRefuelData | null;
-  minRefuelAmount: string;
 }
 
 export interface TransactionOptions {

--- a/sdk/src/types/index.ts
+++ b/sdk/src/types/index.ts
@@ -175,6 +175,28 @@ interface SocketAsset {
   symbol: string;
 }
 
+export interface SocketChainsData {
+  success: boolean;
+  result: {
+    _id: string;
+    name: string;
+    chainId: ChainId;
+    icon: string;
+    isSendingEnabled: boolean;
+    isReceivingEnabled: boolean;
+    blockExplorer: string;
+    nativeAsset: string;
+    limits: {
+      chainId: ChainId;
+      isEnabled: boolean;
+      minAmount: BigNumberish;
+      maxAmount: BigNumberish;
+    }[];
+    gasLimit: BigNumberish;
+    __v: number;
+  }[];
+}
+
 export interface CrosschainQuote extends Quote {
   fromAsset: SocketAsset;
   fromChainId: number;
@@ -183,6 +205,7 @@ export interface CrosschainQuote extends Quote {
   allowanceTarget?: string;
   routes: SocketRoute[];
   refuel: SocketRefuelData | null;
+  minRefuelAmount: string;
 }
 
 export interface TransactionOptions {

--- a/sdk/src/utils/constants.ts
+++ b/sdk/src/utils/constants.ts
@@ -2,6 +2,7 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { ChainId, EthereumAddress } from '../types';
 export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 export const API_BASE_URL = 'https://swap.p.rainbow.me';
+export const SOCKET_BASE_URL = 'https://refuel.socket.tech';
 export const RAINBOW_ROUTER_CONTRACT_ADDRESS =
   '0x00000000009726632680fb29d3f7a9734e3010e2';
 export const SOCKET_REGISTRY_CONTRACT_ADDRESSESS =

--- a/sdk/src/utils/constants.ts
+++ b/sdk/src/utils/constants.ts
@@ -2,7 +2,6 @@ import { BigNumber } from '@ethersproject/bignumber';
 import { ChainId, EthereumAddress } from '../types';
 export const ETH_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE';
 export const API_BASE_URL = 'https://swap.p.rainbow.me';
-export const SOCKET_BASE_URL = 'https://refuel.socket.tech';
 export const RAINBOW_ROUTER_CONTRACT_ADDRESS =
   '0x00000000009726632680fb29d3f7a9734e3010e2';
 export const SOCKET_REGISTRY_CONTRACT_ADDRESSESS =


### PR DESCRIPTION
This adds the `minRefuelAmount` to every response which allows us to calculate ahead of time whether a crosschain swap will have the required funds to make a refuel to the destination chain.