### PR TITLE
Remove explicit inccorect return type in function

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.18",
+  "version": "0.1.17",
   "name": "@rainbow-me/swaps",
   "license": "GPL-3.0",
   "main": "dist/index.js",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.1.17",
+  "version": "0.1.18",
   "name": "@rainbow-me/swaps",
   "license": "GPL-3.0",
   "main": "dist/index.js",

--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -143,7 +143,7 @@ const buildRainbowCrosschainQuoteUrl = ({
 export const getMinRefuelAmount = async (params: {
   chainId: ChainId;
   toChainId: ChainId;
-}): Promise<BigNumberish | null> => {
+}) => {
   const { chainId, toChainId } = params;
   const url = `${API_BASE_URL}/v1/chains`;
   const response = await fetch(url);


### PR DESCRIPTION
I added a explicit return type on the `getMinRefuelAmount` which set it as a `BigNumberish` value however its actually explicitly returning a `string` typescript can figure this out for itself so ive removed the incorrect return type