### PR TITLE
chore: use signer instead of wallet

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -59,6 +59,7 @@
   },
   "dependencies": {
     "@ethersproject/abi": "5.6.0",
+    "@ethersproject/abstract-signer": "5.6.0",
     "@ethersproject/bignumber": "5.6.0",
     "@ethersproject/bytes": "5.6.0",
     "@ethersproject/contracts": "5.6.0",

--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -1,8 +1,8 @@
+import { Signer } from '@ethersproject/abstract-signer';
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Transaction } from '@ethersproject/transactions';
-import { Signer } from 'ethers';
 import RainbowRouterABI from './abi/RainbowRouter.json';
 import {
   ChainId,
@@ -27,6 +27,7 @@ import {
   WRAPPED_ASSET,
 } from './utils/constants';
 import { signPermit } from '.';
+import { Wallet } from '@ethersproject/wallet';
 
 /**
  * Function to get a swap formatted quote url to use with backend
@@ -297,7 +298,7 @@ export const getCrosschainQuote = async (
   return quote as CrosschainQuote;
 };
 
-const calculateDeadline = async (wallet: Signer) => {
+const calculateDeadline = async (wallet: Wallet) => {
   const { timestamp } = await wallet.provider.getBlock('latest');
   return timestamp + PERMIT_EXPIRATION_TS;
 };
@@ -352,9 +353,9 @@ export const fillQuote = async (
     );
   } else if (buyTokenAddress?.toLowerCase() === ethAddressLowerCase) {
     if (permit) {
-      const deadline = await calculateDeadline(wallet);
+      const deadline = await calculateDeadline(wallet as Wallet);
       const permitSignature = await signPermit(
-        wallet,
+        wallet as Wallet,
         sellTokenAddress,
         quote.from,
         instance.address,
@@ -389,9 +390,9 @@ export const fillQuote = async (
     }
   } else {
     if (permit) {
-      const deadline = await calculateDeadline(wallet);
+      const deadline = await calculateDeadline(wallet as Wallet);
       const permitSignature = await signPermit(
-        wallet,
+        wallet as Wallet,
         sellTokenAddress,
         quote.from,
         instance.address,

--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -3,6 +3,7 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Transaction } from '@ethersproject/transactions';
+import { Wallet } from '@ethersproject/wallet';
 import RainbowRouterABI from './abi/RainbowRouter.json';
 import {
   ChainId,
@@ -27,7 +28,6 @@ import {
   WRAPPED_ASSET,
 } from './utils/constants';
 import { signPermit } from '.';
-import { Wallet } from '@ethersproject/wallet';
 
 /**
  * Function to get a swap formatted quote url to use with backend

--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -2,7 +2,7 @@ import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Transaction } from '@ethersproject/transactions';
-import { Wallet } from '@ethersproject/wallet';
+import { Signer } from 'ethers';
 import RainbowRouterABI from './abi/RainbowRouter.json';
 import {
   ChainId,
@@ -297,7 +297,7 @@ export const getCrosschainQuote = async (
   return quote as CrosschainQuote;
 };
 
-const calculateDeadline = async (wallet: Wallet) => {
+const calculateDeadline = async (wallet: Signer) => {
   const { timestamp } = await wallet.provider.getBlock('latest');
   return timestamp + PERMIT_EXPIRATION_TS;
 };
@@ -307,7 +307,7 @@ const calculateDeadline = async (wallet: Wallet) => {
  *
  * @param {Quote} quote
  * @param {TransactionOptions} transactionOptions
- * @param {Wallet} wallet
+ * @param {Signer} wallet
  * @param {boolean} permit
  * @param {number} ChainId
  * @returns {Promise<Transaction>}
@@ -315,7 +315,7 @@ const calculateDeadline = async (wallet: Wallet) => {
 export const fillQuote = async (
   quote: Quote,
   transactionOptions: TransactionOptions,
-  wallet: Wallet,
+  wallet: Signer,
   permit: boolean,
   chainId: ChainId
 ): Promise<Transaction> => {
@@ -435,13 +435,13 @@ export const fillQuote = async (
  *
  * @param {CrosschainQuote} quote
  * @param {TransactionOptions} transactionOptions
- * @param {Wallet} wallet
+ * @param {Signer} wallet
  * @returns {Promise<Transaction>}
  */
 export const fillCrosschainQuote = async (
   quote: CrosschainQuote,
   transactionOptions: TransactionOptions,
-  wallet: Wallet
+  wallet: Signer
 ): Promise<Transaction> => {
   const { to, data, from, value } = quote;
   const swapTx = await wallet.sendTransaction({

--- a/sdk/src/utils/permit.ts
+++ b/sdk/src/utils/permit.ts
@@ -1,7 +1,7 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { splitSignature } from '@ethersproject/bytes';
 import { Contract } from '@ethersproject/contracts';
-import { Signer } from 'ethers';
+import { Wallet } from '@ethersproject/wallet';
 import {
   signTypedData,
   SignTypedDataVersion,
@@ -130,7 +130,7 @@ const PERMIT_ALLOWED_TYPE = [
 ];
 
 export async function signPermit(
-  wallet: Signer,
+  wallet: Wallet,
   tokenAddress: EthereumAddress,
   owner: EthereumAddress,
   spender: EthereumAddress,

--- a/sdk/src/utils/permit.ts
+++ b/sdk/src/utils/permit.ts
@@ -1,7 +1,7 @@
 import { BigNumber, BigNumberish } from '@ethersproject/bignumber';
 import { splitSignature } from '@ethersproject/bytes';
 import { Contract } from '@ethersproject/contracts';
-import { Wallet } from '@ethersproject/wallet';
+import { Signer } from 'ethers';
 import {
   signTypedData,
   SignTypedDataVersion,
@@ -130,7 +130,7 @@ const PERMIT_ALLOWED_TYPE = [
 ];
 
 export async function signPermit(
-  wallet: Wallet,
+  wallet: Signer,
   tokenAddress: EthereumAddress,
   owner: EthereumAddress,
   spender: EthereumAddress,

--- a/sdk/src/wrappedAsset.ts
+++ b/sdk/src/wrappedAsset.ts
@@ -2,7 +2,7 @@ import { BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Transaction } from '@ethersproject/transactions';
-import { Wallet } from '@ethersproject/wallet';
+import { Signer } from 'ethers';
 import { default as WethAbi } from './abi/Weth.json';
 import { WRAPPED_ASSET } from './utils/constants';
 import { ChainId, TransactionOptions } from '.';
@@ -11,12 +11,12 @@ import { ChainId, TransactionOptions } from '.';
  * Function to wrap a specific amount of the native asset
  * for the specified wallet from its ERC20 version
  * @param {BigNumberish} amount
- * @param {Wallet} wallet
+ * @param {Signer} wallet
  * @returns {Promise<Transaction>}
  */
 export const wrapNativeAsset = async (
   amount: BigNumberish,
-  wallet: Wallet,
+  wallet: Signer,
   chainId: ChainId = ChainId.mainnet,
   transactionOptions: TransactionOptions = {}
 ): Promise<Transaction> => {
@@ -36,12 +36,12 @@ export const wrapNativeAsset = async (
  * Function to unwrap a specific amount of the native asset
  * for the specified wallet from its ERC20 version
  * @param {BigNumberish} amount
- * @param {Wallet} wallet
+ * @param {Signer} wallet
  * @returns {Promise<Transaction>}
  */
 export const unwrapNativeAsset = async (
   amount: BigNumberish,
-  wallet: Wallet,
+  wallet: Signer,
   chainId: ChainId = ChainId.mainnet,
   transactionOptions: TransactionOptions = {}
 ): Promise<Transaction> => {

--- a/sdk/src/wrappedAsset.ts
+++ b/sdk/src/wrappedAsset.ts
@@ -1,8 +1,8 @@
+import { Signer } from '@ethersproject/abstract-signer';
 import { BigNumberish } from '@ethersproject/bignumber';
 import { Contract } from '@ethersproject/contracts';
 import { StaticJsonRpcProvider } from '@ethersproject/providers';
 import { Transaction } from '@ethersproject/transactions';
-import { Signer } from 'ethers';
 import { default as WethAbi } from './abi/Weth.json';
 import { WRAPPED_ASSET } from './utils/constants';
 import { ChainId, TransactionOptions } from '.';
@@ -58,7 +58,7 @@ export const unwrapNativeAsset = async (
  * Function that returns a pointer to the smart contract
  * function that wraps or unwraps, to be used by estimateGas calls
  * @param {string} name
- * @param {StaticJsonRpcProvider} provider]
+ * @param {StaticJsonRpcProvider} provider
  * @returns {Promise<Transaction>}
  */
 export const getWrappedAssetMethod = (

--- a/sdk/yarn.lock
+++ b/sdk/yarn.lock
@@ -976,7 +976,7 @@
     "@ethersproject/transactions" "^5.6.0"
     "@ethersproject/web" "^5.6.0"
 
-"@ethersproject/abstract-signer@^5.6.0":
+"@ethersproject/abstract-signer@5.6.0", "@ethersproject/abstract-signer@^5.6.0":
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/abstract-signer/-/abstract-signer-5.6.0.tgz#9cd7ae9211c2b123a3b29bf47aab17d4d016e3e7"
   integrity sha512-WOqnG0NJKtI8n0wWZPReHtaLkDByPL67tn4nBaDAhmVq8sjHTPbCdz4DRhVu/cfTOvfy9w3iq5QZ7BX7zw56BQ==


### PR DESCRIPTION
changes Wallet types to Signer, step needed as part of the ledger work

There's a few Wallet specific functions used to handle permit so ive left that alone. permit was disabled on v1 ledger support, need to get with @brunobar79 to confirm why 