### PR TITLE
blow up quote filling w/ incorrect quote.swapType

### DIFF
--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -29,6 +29,7 @@ import {
 import { signPermit } from './utils/permit';
 import { getReferrerCode } from './utils/referrer';
 import { sanityCheckAddress } from './utils/sanity_check';
+import { checkSwapType } from './utils/check_swap_type';
 
 
 /**
@@ -435,6 +436,8 @@ export const fillQuote = async (
   chainId: ChainId,
   referrer?: string
 ): Promise<Transaction> => {
+  checkSwapType(quote?.swapType, false);
+
   const instance = new Contract(
     getRainbowRouterContractAddress(chainId),
     RainbowRouterABI,
@@ -580,6 +583,7 @@ export const fillCrosschainQuote = async (
   const { data, from, value } = quote;
 
   sanityCheckAddress(quote?.to);
+  checkSwapType(quote?.swapType, true);
 
   let txData = data;
   if (referrer) {

--- a/sdk/src/utils/check_swap_type.ts
+++ b/sdk/src/utils/check_swap_type.ts
@@ -1,0 +1,16 @@
+import { SwapType } from '../types';
+
+/**
+ * @param swapType The swap type provided by the quote.
+ * @param isCrossChain Whether the swap is cross-chain.
+ * @throws {Error} Throws an error if the swap type is not correct.
+ */
+
+export function checkSwapType(swapType: SwapType, isCrossChain: boolean) {
+  if (isCrossChain && swapType !== SwapType.crossChain) {
+    throw new Error('Normal quote provided for cross-chain swap');
+  }
+  if (!isCrossChain && swapType !== SwapType.normal) {
+    throw new Error('Crosschain quote provided for normal swap');
+  }
+}


### PR DESCRIPTION
While discussing beeEx-1752 (Bug: User's funds sent to Rainbow Router instead of bridging) this possibility came up. I am not linking to the issue because we've since lessened our confidence in this being the cause, but we should check this anyway.