### PR TITLE
fix: safely lowercase addresses

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,7 @@ jobs:
         uses: crytic/slither-action@main
         id: slither
         with:
-          node-version: ${{ env.node-version }}
+          node-version: '16.16.0'
           target: 'smart-contracts'
           slither-args: '--exclude assembly,low-level-calls,solc-version,pragma,naming-convention,external-function,too-many-digits,block-timestamp,immutable-states'
 

--- a/sdk/src/quotes.ts
+++ b/sdk/src/quotes.ts
@@ -66,7 +66,7 @@ export const getRainbowRouterContractAddress = (chainId: ChainId) => {
  * @param {ChainId} chainId
  * @returns {string}
  */
-export const getAmmContractAddress = (chainId: ChainId) => {
+export const getAmmContractAddress = (chainId: ChainId): string | undefined => {
   return AMM_CONTRACT_ADDRESSES[chainId];
 };
 
@@ -448,9 +448,12 @@ export const isAllowedTargetContract = (
   targetContract: string,
   chainId: ChainId
 ) => {
+  const rainbowRouterContractAddress =
+    getRainbowRouterContractAddress(chainId) ?? '';
+  const ammContractAddress = getAmmContractAddress(chainId) ?? '';
   return [
-    getRainbowRouterContractAddress(chainId).toLowerCase(),
-    getAmmContractAddress(chainId).toLowerCase(),
+    rainbowRouterContractAddress.toLowerCase(),
+    ammContractAddress.toLowerCase(),
   ].includes(targetContract.toLowerCase());
 };
 


### PR DESCRIPTION
Prevent unsupported chainIds from blowing up `fillQuote`. No behavior changes other than preventing `(undefined).toLowerCase()`.