### PR TITLE
chore: github tag, release automation

### DIFF
--- a/sdk/package.json
+++ b/sdk/package.json
@@ -23,7 +23,7 @@
     "analyze": "size-limit --why",
     "changeset": "changeset",
     "release": "yarn release:verify-git && yarn release:publish && yarn release:github",
-    "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep -q \"main\"",
+    "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep -q main",
     "release:publish": "yarn build && changeset publish --tag latest && git push --follow-tags",
     "release:github": "TAG=$(git describe --tags --abbrev=0) && awk '/^## /{if(p++)exit;next}p' CHANGELOG.md | gh release create \"$TAG\" --notes-file -"
   },

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -22,8 +22,10 @@
     "size": "size-limit",
     "analyze": "size-limit --why",
     "changeset": "changeset",
-    "release": "yarn release:verify-git && yarn build && changeset publish --tag latest && git push --follow-tags",
-    "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep \"main\""
+    "release": "yarn release:verify-git && yarn release:publish && yarn release:github",
+    "release:verify-git": "git diff --exit-code && git rev-parse --abbrev-ref HEAD | grep -q \"main\"",
+    "release:publish": "yarn build && changeset publish --tag latest && git push --follow-tags",
+    "release:github": "TAG=$(git describe --tags --abbrev=0) && awk '/^## /{if(p++)exit;next}p' CHANGELOG.md | gh release create \"$TAG\" --notes-file -"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Improved release process by splitting the release script into three separate commands:

1. `release:verify-git`: Ensures we're on the main branch with no uncommitted changes
2. `release:publish`: Builds, publishes to npm with the latest tag, and pushes git tags
3. `release:github`: Creates a GitHub release using the latest tag and changelog content

The main `release` command now orchestrates these three steps in sequence, making the process more modular and maintainable.